### PR TITLE
show error when server fails to start

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -89,8 +89,11 @@ app.post('/bundle', function(req, res) {
 
 //FIRE IT UP
 app.listen(config.port);
-Logger.debug("TiShadow server started. Go to http://"+ config.host + ":" + config.port);
-
+if (app.address() != null) {
+    Logger.debug("TiShadow server started. Go to http://"+ config.host + ":" + config.port);
+} else {
+    Logger.error("Failed to start server on port: " + config.port );
+}
 
 //WEB SOCKET STUFF
 var devices = {};


### PR DESCRIPTION
The server did not explicitly state a failure when attempting to start on an already allocated port. 

This fix checks to see if the server has an address and states a failure if the server start has been unsuccessful. 
