### PR TITLE
Updated pull request for adding titleid and textid support in TiShadow.

### DIFF
--- a/cli/support/compiler.js
+++ b/cli/support/compiler.js
@@ -21,6 +21,10 @@ function prepare(src, dst, callback) {
       .replace(/Ti(tanium)?.include\(/g, "__p.include(this,")
       .replace(/Ti.Locale.getString/g, "L")
       .replace(/([ :=\(])(['"])(\/[^'"].*?)(['"])/g, "$1__p.file($2$3$4)") // ignores "/"
+      // Replace strings like ".titleid = 'save'" -> "title = L('save')"
+      .replace(/\.(title|text)id\s{0,}\=\s{0,}['"](\w+)['"]/g, '.$1 = L(\'$2\')')
+      // Replace strings like "titleid: 'save'" -> "title: L('save')"
+      .replace(/\b(title|text)id:\s{0,}['"](\w+)['"]/g, '$1: L(\'$2\')')
       .replace(/Ti(tanium)?.API/g, "__log");
     if (src.match("_spec.js$")) {
       src_text =  "var jasmine = require('/lib/jasmine-1.2.0');var methods = ['spyOn','it','xit','expect','runs','waits','waitsFor','beforeEach','afterEach','describe','xdescribe'];methods.forEach(function(method) {this[method] = jasmine[method];});"


### PR DESCRIPTION
I changed source code and moved regexps to cli/support/compiler.js. I also updated them: now only titleid and textid will be matched.
