### PR TITLE
fixed zip module setting

### DIFF
--- a/cli/support/appify.js
+++ b/cli/support/appify.js
@@ -14,8 +14,8 @@ _.templateSettings = {
         '<module platform="iphone" version="0.1">yy.tidynamicfont</module>',
         '<module platform="iphone" version="0.3">net.iamyellow.tiws</module>',
         '<module platform="android" version="0.1">net.iamyellow.tiws</module>',
-        '<module platform="iphone" version="0.1.21">zipfile</module>',
-        '<module platform="android" version="0.2">com.yydigital.zip</module>'
+        '<module platform="iphone" version="1.0.2">ti.compression</module>',
+        '<module platform="android" version="2.0.1">ti.compression</module>'
  ];
 
 


### PR DESCRIPTION
Fixed compile error with Titanium CLI below:

<pre>
[ERROR] Could not find all required Titanium Modules:
[ERROR]    id: zipfile   version: 0.1.21     platform: iphone    deploy-type: test
</pre>


used Titanium Command-Line Interface, CLI version 3.0.24, Titanium SDK version 3.0.2.GA
