### PR TITLE
Added localization fallback to 'en'

### DIFF
--- a/app/Resources/api/Localisation.js
+++ b/app/Resources/api/Localisation.js
@@ -6,9 +6,12 @@ function loadFile() {
   lookup = {};
   var file = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory + TiShadow.currentApp + "/" + exports.locale + "/strings.xml");
   if (!file.exists()) {
-    log.warn(Ti.Filesystem.applicationDataDirectory + TiShadow.currentApp + "/" + exports.locale + "/strings.xml");
-    log.warn("Language file for '" + exports.locale + "' does not exist");
-    return;
+    file = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory + TiShadow.currentApp + "/en/strings.xml");
+    if (!file.exists()) {
+      log.warn(Ti.Filesystem.applicationDataDirectory + TiShadow.currentApp + "/" + exports.locale + "/strings.xml");
+      log.warn("Language file for both '" + exports.locale + "' and 'en' fallback do not exist");
+      return;
+    }
   }
   var xml_string = file.read().text;
   var doc = Ti.XML.parseString(xml_string);


### PR DESCRIPTION
Just like the original `L`, TiShadow's should also fall back to `en` when there's no localization file found for the  current language.
