### PR TITLE
TypeError: Cannot call method 'match' of undefined

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -156,7 +156,9 @@ sio.sockets.on('connection', function(socket) {
     socket.get("name", function(err, name) {
       socket.get("room", function(err, room) {
         if (name && room) {
+          data.level = data.level || '';
           data.name = name;
+          data.message = data.message || '';
           Logger.log(data.level, data.name, data.message);
           sio.sockets.in(room).emit("device_log", data);
         }


### PR DESCRIPTION
when run spec command an error occurred in v1.0.0.

```
/Users/astronaughts/TiShadow/cli/support/socket.js:23
    if (config.isSpec && data.message.match("Runner Finished$")) {
                                      ^
TypeError: Cannot call method 'match' of undefined
    at SocketNamespace.exports.connect (/Users/astronaughts/TiShadow/cli/support/socket.js:23:39)
    at SocketNamespace.EventEmitter.emit [as $emit] (/Users/astronaughts/TiShadow/node_modules/socket.io-client/lib/events.js:165:15)
    at SocketNamespace.onPacket (/Users/astronaughts/TiShadow/node_modules/socket.io-client/lib/namespace.js:182:20)
    at Socket.onPacket (/Users/astronaughts/TiShadow/node_modules/socket.io-client/lib/socket.js:443:30)
    at Transport.onPacket (/Users/astronaughts/TiShadow/node_modules/socket.io-client/lib/transport.js:98:17)
    at Transport.onData (/Users/astronaughts/TiShadow/node_modules/socket.io-client/lib/transport.js:69:16)
    at WebSocket.WS.open.websocket.onmessage (/Users/astronaughts/TiShadow/node_modules/socket.io-client/lib/transports/websocket.js:73:12)
    at WebSocket.onMessage (/Users/astronaughts/TiShadow/node_modules/socket.io-client/node_modules/ws/lib/WebSocket.js:321:18)
    at WebSocket.EventEmitter.emit (events.js:99:17)
    at Receiver.self._receiver.ontext (/Users/astronaughts/TiShadow/node_modules/socket.io-client/node_modules/ws/lib/WebSocket.js:544:10)
```
