### PR TITLE
Fix for: Can't test due to corrupt ZIP-files

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "restler": "~2.0.1",
     "wrench": "1.4.x",
     "underscore": "1.4.x",
-    "archiver": "0.4.3",
+    "archiver": "0.4.6",
     "express": "~3.3.4",
-    "watch": "~0.8.0"
+    "watch": "~0.8.0",
+    "lazystream": "~0.1.0"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
Issue: https://groups.google.com/forum/#!topic/tishadow/IU4OY8y_UMs

After doing some extensive research, it seems to be an issue with Archiver. The actual zip file is corrupt. Testing it with unzip -t <zipfile> returns one or more errors. It does not seem to be a widespread error, because Archiver also can't reproduce it (https://github.com/ctalkington/node-archiver/issues/34)

I do however have a fix. I've rewritten bundle.js to work asynchronously through the files (as opposed to recursive) and added the fastest compression. This seems to have fixed the issue, without having to wait for Archiver to fix the issue.

I currently don't create empty directories anymore, because the app directory isn't readable after all. If this is an issue, I'll gladly put support into this commit.
