### PR TITLE
Fix error when running app with update or patch and having app.tss file in theme

### DIFF
--- a/cli/support/alloy.js
+++ b/cli/support/alloy.js
@@ -77,6 +77,7 @@ exports.mapFiles = function(last_stat) {
       }
 
       file_path = file_path.slice(2);
+      la = file_path.length - 1;
 
       if (file_path[0] === 'assets') {
         file_path.shift();


### PR DESCRIPTION
When trying to run the app with patch or update options the build process fails.

I have an app with multiple themes, and it fails when trying to process the app.tss file of the theme

``` bash
~/workspace/eventwo_app$ tishadow run --update
[INFO] Beginning Build Process

/usr/local/lib/node_modules/tishadow/node_modules/xml2js/lib/xml2js.js:216
          throw ex;
                ^
TypeError: Cannot call method 'match' of undefined
    at Object.exports.mapFiles (/usr/local/lib/node_modules/tishadow/cli/support/alloy.js:84:61)
    at /usr/local/lib/node_modules/tishadow/cli/support/compiler.js:97:43
    at /usr/local/lib/node_modules/tishadow/cli/support/config.js:63:5
    at /usr/local/lib/node_modules/tishadow/cli/support/config.js:17:9
    at Parser.<anonymous> (/usr/local/lib/node_modules/tishadow/node_modules/xml2js/lib/xml2js.js:199:18)
    at Parser.EventEmitter.emit (events.js:95:17)
    at Object.saxParser.onclosetag (/usr/local/lib/node_modules/tishadow/node_modules/xml2js/lib/xml2js.js:183:24)
    at emit (/usr/local/lib/node_modules/tishadow/node_modules/xml2js/node_modules/sax/lib/sax.js:602:33)
    at emitNode (/usr/local/lib/node_modules/tishadow/node_modules/xml2js/node_modules/sax/lib/sax.js:607:3)
    at closeTag (/usr/local/lib/node_modules/tishadow/node_modules/xml2js/node_modules/sax/lib/sax.js:848:5)
    at Object.write (/usr/local/lib/node_modules/tishadow/node_modules/xml2js/node_modules/sax/lib/sax.js:1267:29)
```
