### PR TITLE
Using the 'info' CSS class from Bootstrap to display info messages

### DIFF
--- a/server/public/javascript/main.js
+++ b/server/public/javascript/main.js
@@ -13,7 +13,7 @@ TiShadow.init = function (session, guest){
   socket.on('device_log', function(e) {
     var now = new Date();
     var log = now.getHours() + ":" + now.getMinutes() + ":" + now.getSeconds() + " [" + e.level + "] [" + e.name + "]    " + (e.message === undefined ? 'undefined' : e.message.toString().replace("\n","<br/>"));
-    var style = e.level === "ERROR"  || e.level === "FAIL" ? " error" : e.level === "WARN" ? "" : " success"
+    var style = e.level === "ERROR"  || e.level === "FAIL" ? " error" : e.level === "WARN" ? "" : e.level === "INFO" ? " info" : " success";
     $(".console").append("<div class='alert-message" + style + "'>" + log + "</div>");
     $(".console").scrollTop($(".console")[0].scrollHeight);
   });


### PR DESCRIPTION
Makes the [INFO] and [DEBUG] messages look different in the console of the TiShadow server page.
