### PR TITLE
Removing leading slash from require() statement

### DIFF
--- a/app/Resources/api/PlatformRequire.js
+++ b/app/Resources/api/PlatformRequire.js
@@ -129,6 +129,7 @@ exports.file = function(extension) {
   if (typeof extension !== "string") {
     return;
   }
+  extension = extension.replace(/^\//, '');
   var base = Ti.Filesystem.applicationDataDirectory + "/" + require("/api/TiShadow").currentApp + "/";
   var path = base + extension,
       platform_path =  base + (os === "android" ? "android" : "iphone") + "/" + extension;


### PR DESCRIPTION
The final path will otherwise contain `//`, which is not a problem for requiring it, but because of the TiShadow caching them by path, it will lead to 2 instances if you refer the same module once with and once without leading slash.
