### PR TITLE
Closes #124

### DIFF
--- a/app/Resources/api/PlatformRequire.js
+++ b/app/Resources/api/PlatformRequire.js
@@ -127,7 +127,7 @@ function densityFile(file) {
 }
 exports.file = function(extension) {
   if (typeof extension !== "string") {
-    return;
+    return extension;
   }
   extension = extension.replace(/^\//, '');
   var base = Ti.Filesystem.applicationDataDirectory + "/" + require("/api/TiShadow").currentApp + "/";


### PR DESCRIPTION
If `file()`'s argument is not a string, it should return it.
