### PR TITLE
Fixes express not working with device on Android

### DIFF
--- a/plugin/yy.tishadow/1.0/hooks/shadow.js
+++ b/plugin/yy.tishadow/1.0/hooks/shadow.js
@@ -93,6 +93,9 @@ function preCompileHook(build, finished) {
       }
       build.nativeLibModules.push(module_props);
     });
+    if (!build.moduleSearchPaths) {
+      build.moduleSearchPaths = [];
+    }
     build.moduleSearchPaths.push(path.join(new_project_dir,"modules"));
     finished();
     commands.startServer(logger);


### PR DESCRIPTION
Seems like `moduleSearchpaths` doesn't always exist, at least not when building to an Android device.
