### PR TITLE
Support JUnit xml reports for all connected devices

### DIFF
--- a/cli/support/socket.js
+++ b/cli/support/socket.js
@@ -7,6 +7,7 @@ var logger = require("../../server/logger"),
 
 exports.connect = function(onconnect) {
   var socket = io.connect("http"+ (config.isTiCaster ? "s" : "") + "://" + config.host + ":" + config.port);
+  var running = 0;
   socket.on('connect', function(data) {
     socket.emit("join", {name: 'controller', room: config.room});
     if (onconnect && typeof onconnect === 'function') {
@@ -14,9 +15,11 @@ exports.connect = function(onconnect) {
     }
   });
   socket.on('device_connect', function(e){
+    running++;
     logger.log("INFO", e.name, "Connected");
   });
   socket.on('device_disconnect', function(e){
+    running--;
     logger.log("WARN", e.name,"Disconnected");
   });
   socket.on('device_log', function(data) {
@@ -25,7 +28,10 @@ exports.connect = function(onconnect) {
     } else if (config.isJUnit && data.level === "TEST") {
       var target_file = path.join(config.tishadow_build, data.name.replace(/(, |\.)/g, "_") + "_result.xml");
       fs.writeFileSync(target_file,data.message);
-      socket.disconnect();
+      running--;
+      if (running <= 0) {
+        socket.disconnect();
+      }
       logger.info("Report Generated: " + target_file);
     } else if (!config.isJUnit) {
       logger.log(data.level, data.name, data.message);


### PR DESCRIPTION
When running "spec --junit-xml", Instead of disconnecting the socket on the first TEST devile_log event, wait
for every connected device to report their results and then disconnects the socket.
fixes dbankier/TiShadow#178
