### PR TITLE
Fixes missing icons on home screen

### DIFF
--- a/app/Resources/ui/AppList.js
+++ b/app/Resources/ui/AppList.js
@@ -63,6 +63,7 @@ function AppList() {
       //test application directory
       if (file_name.indexOf(".") == -1) {
       	var platform = Ti.Platform.name;
+      	platform = platform.toLowerCase().indexOf("iphone") != -1 ? "iphone" : platform; //ios is "iPhone OS" for some reason
         var app_js = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory + "/" + file_name + "/" + platform, 'app.js');
         if (app_js.exists()) { // APPLICATION DIRECTORY
           var icon_path = Ti.Filesystem.applicationDataDirectory + file_name + "/" + platform + "/appicon.png";


### PR DESCRIPTION
Previous code didn't made allowance for appicon.png to be @
/app_data/appname/"platform"/appicon.js 

but did not account for app.js having a similar path. Not sure why this worked in an old version, but not in the latest.

App JS is @

var app_js = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory + "/" + file_name + "/" + platform, 'app.js');

not

var app_js = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory + "/" + file_name, 'app.js');
