### PR TITLE
Re-introducing an app event for apps to do cleanup

### DIFF
--- a/app/Resources/api/TiShadow.js
+++ b/app/Resources/api/TiShadow.js
@@ -128,12 +128,14 @@ exports.closeApp = function() {
   Ti.App.Properties.setString("tishadow::currentApp","" );
   Ti.App.Properties.setBool("tishadow::reconnectOnly",true );
   //exports.disconnect();
+  Ti.App.fireEvent('tishadow:close');
   Ti.App._restart();
 };
 exports.nextApp = function(name) {
   Ti.App.Properties.setString("tishadow::currentApp", name ? name.replace(/ /g,"_") : exports.currentApp);
   Ti.App.Properties.setBool("tishadow::reconnectOnly",false );
   //exports.disconnect();
+  Ti.App.fireEvent('tishadow:close');
   Ti.App._restart();
 };
 exports.launchApp = function(name) {


### PR DESCRIPTION
Until Appcelerator fixes app-events not being cleared on restart, apps needs to know when restart happens so they can clean up:

```
if (!ENV_PRODUCTION && Ti.Shadow) {
    Ti.App.addEventListener('tishadow:close', function() {
        Ti.App.removeEventListener('resumed', onResume);
    });
}
```
