### PR TITLE
Create appify destination if not exist

### DIFF
--- a/cli/support/appify.js
+++ b/cli/support/appify.js
@@ -1,5 +1,6 @@
 var logger = require("../../server/logger.js"),
     fs = require("fs"),
+    mkdirp = require('mkdirp'),
     wrench = require("wrench"),
     path = require("path"),
     tishadow_app = path.join(__dirname, "../..","app"),
@@ -29,8 +30,10 @@ _.templateSettings = {
 exports.copyCoreProject = function(env) {
   var dest = env.destination || ".";
   if (!fs.existsSync(dest) || !fs.lstatSync(dest).isDirectory()) {
-    logger.error("Destination folder does not exist.");
-    return false;
+    mkdirp(dest, function(err) {
+      logger.error("Could not create destination directory. Error: " + err);
+      return false;
+    });
   }
   if (dest === ".") {
     logger.error("You really don't want to write to the current directory.");

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "tiapp": "0.0.2",
     "gaze": "~0.4.3",
     "glob": "~3.2.8",
-    "async": "~0.2.9"
+    "async": "~0.2.9",
+    "mkdirp": "~0.3.5"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
I don't know if this is exactly how you'd implement it, but I think it should create the destination directory if it doesn't exist.
