### PR TITLE
Fix "Connect" button truncation due to fixed width

### DIFF
--- a/app/Resources/ui/NavBar.js
+++ b/app/Resources/ui/NavBar.js
@@ -1,4 +1,4 @@
-var connect_button = Ti.UI.createButton({title:'Connect', top: '5dp', width: "60dp", height: "30dp", left: "10dp"});
+var connect_button = Ti.UI.createButton({title:'Connect', top: '5dp', left: "10dp"});
 
 module.exports = {
   add: function(o) {


### PR DESCRIPTION
Connect button should be using Ti.UI.FIT which is the default width/height when none is specified.

Currently it is "C...ect" as the label width won't accommodate the full text.
