### PR TITLE
Update tiapp.xml

### DIFF
--- a/app/tiapp.xml
+++ b/app/tiapp.xml
@@ -7,7 +7,7 @@
         <target device="android">true</target>
         <target device="blackberry">false</target>
     </deployment-targets>
-    <sdk-version>3.2.0.GA</sdk-version>
+    <sdk-version>3.2.2.GA</sdk-version>
     <id>{{APPID}}</id>
     <name>TiShadow</name>
     <version>1.0</version>


### PR DESCRIPTION
Bump SDK version number. TiShadow app failed to build with 3.2.0.GA setting after Xcode5.1 upgrade
