### PR TITLE
fix issue that app will crash when we console.log(null)

### DIFF
--- a/app/Resources/api/Log.js
+++ b/app/Resources/api/Log.js
@@ -1,34 +1,43 @@
+var logLevels = ['info', 'error', 'debug', 'trace', 'repl', 'warn', 'pass', 'fail', 'test'];
 
-['info','error','debug','trace','repl','warn','pass','fail','test'].forEach(function(level){
-  exports[level] = function(message) {
-  	_write(level, message);
+logLevels.forEach(function(level) {
+  exports[level] = function() {
+    Array.prototype.unshift.call(arguments, level)
+    _write.apply(null, arguments);
   };
 });
 
-exports.log = function(level, message) {
-	if (typeof message === 'undefined') {
-		message = level;
-		level = 'info';
-	}
-	_write(level, message);
+exports.log = function(level) {
+  // If the value of level is not recognized,
+  // an info-level message prefixed with the value is logged.
+  // http://docs.appcelerator.com/titanium/latest/#!/api/Titanium.API-method-log
+  if (logLevels.indexOf(level) === -1) {
+    Array.prototype.unshift.call(arguments, 'info')
+  }
+  _write.apply(null, arguments);
 };
 
-function _write(level, message) {
-  	if (typeof message === 'object') {
-  		message = JSON.stringify(message, function (key, val) {
-  			if (typeof val !== 'object') {
-  				return val;
-  			}
-  			try {
-  				JSON.stringify(val);
-  				return val;
-  			} catch (err) {
-  				return undefined;
-  			}
-  		}, 4);
-  	}
-    require("/api/TiShadow").emitLog({
-      level: level.toUpperCase(),
-      message: message
-    });
+function _write() {
+  var upperCaseLevel = Array.prototype.shift.call(arguments).toUpperCase();
+
+  Array.prototype.forEach.call(arguments, function(msg, i, messages) {
+    if (typeof msg === 'object') {
+      messages[i] = JSON.stringify(msg, function(key, val) {
+        if (typeof val !== 'object') {
+          return val;
+        }
+        try {
+          JSON.stringify(val);
+          return val;
+        } catch (err) {
+          return undefined;
+        }
+      }, 4);
+    }
+  });
+
+  require("/api/TiShadow").emitLog({
+    level: upperCaseLevel,
+    message: Array.prototype.join.call(arguments, ' ')
+  });
 }

--- a/cli/support/uglify.js
+++ b/cli/support/uglify.js
@@ -69,6 +69,10 @@ var convert = new UglifyJS.TreeTransformer(null, function(node){
     }
     if (node.expression.start.value === "console") {
       if (typeof node.expression.property === 'string') {
+        // console.log(...) => __log.log('info', ...)
+        if (node.expression.property === 'log') {
+          node.args.unshift(new UglifyJS.AST_String({value: 'info'}));
+        }
         return functionCall("__log."+node.expression.end.value, node.args);
       } else {
         return functionCallByNode(new UglifyJS.AST_Sub({


### PR DESCRIPTION
App will crash when we pass `null` as the first parameter to `console.log()`

You may also notice that `console.log()` is different from `Ti.API.log()`

This PR also enhances Log to accept more than one message, as [Titanium docs](http://docs.appcelerator.com/titanium/latest/#!/api/Global.console-method-log) says:

> The message to log can either be a single argument, or any number of arguments, which will be converted to strings and then concatenated together with a space character.
