### PR TITLE
Added Ti.Database in Includes.js

### DIFF
--- a/app/Resources/api/Includes.js
+++ b/app/Resources/api/Includes.js
@@ -52,6 +52,7 @@ var includes = [
   Ti.Utils,
   Ti.Contacts.createGroup,
   Ti.Contacts.createPerson,
+  Ti.Database,
   Ti.Database.open,
   Ti.Database.execute,
   Ti.Facebook,


### PR DESCRIPTION
[ERROR] [iphone, 7.1, 10.1.1.6] No support for Titanium.Database in MobileWeb environment.
[ERROR] [iphone, 7.1, 10.1.1.6] TypeError: 'undefined' is not an object (evaluating '__p.require("alloy/models/" + ucfirst(name)).Collection')

When I try to build the iphone device (4s), there was an error as above. But work well with smulator.
So I added database package in Includes.js after that work well both. 
