### PR TITLE
Updated argsToPath to support more than two arguments per Ti.Filesystem.getFile documentation

### DIFF
--- a/cli/support/uglify.js
+++ b/cli/support/uglify.js
@@ -32,11 +32,14 @@ function addAppName(node) {
 }
 
 function argsToPath(args) {
-	if (args.length > 1)  {
-		return binaryAdd(args[0],/*binaryAdd(args[0], symbol('"/"')),*/ argsToPath(_.tail(args)));
-	} else {
-		return args[0];
-	}
+    var path = args[0];
+    if (args.length > 1) {
+        for (var i = 1; i < args.length - 1; ++i) {
+            path = binaryAdd(path, binaryAdd(args[i], symbol('"/"')));
+        }
+        path = binaryAdd(path, _.last(args));
+    }
+    return path;
 }
 function couldBeAsset(name) {
   return typeof name === 'string' && name.toLowerCase().match("image$")  ||

--- a/test/expected/filesystem.js
+++ b/test/expected/filesystem.js
@@ -2,6 +2,10 @@ Ti.Filesystem.getFile(__p.file(Ti.Filesystem.applicationDataDirectory + require(
 
 Ti.Filesystem.getFile(__p.file(Ti.Filesystem.applicationDataDirectory + require("/api/TiShadow").currentApp + "/" + "sounds/my.wav"));
 
+Ti.Filesystem.getFile(__p.file(Ti.Filesystem.applicationDataDirectory + require("/api/TiShadow").currentApp + "/" + ("sounds" + "/") + "my.wav"));
+
+Ti.Filesystem.getFile(__p.file(Ti.Filesystem.applicationDataDirectory + require("/api/TiShadow").currentApp + "/" + ("sounds" + "/") + ("music" + "/") + "my.wav"));
+
 Ti.Filesystem.getApplicationDataDirectory() + require("/api/TiShadow").currentApp + "/";
 
 Ti.Filesystem.applicationDataDirectory + require("/api/TiShadow").currentApp + "/" + "sounds/my.wav";

--- a/test/fixtures/filesystem.js
+++ b/test/fixtures/filesystem.js
@@ -1,4 +1,6 @@
 Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory + "sounds/my.wav");
 Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "sounds/my.wav");
+Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "sounds", "my.wav");
+Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "sounds", "music", "my.wav");
 Ti.Filesystem.getResourcesDirectory();
 Ti.Filesystem.resourcesDirectory + "sounds/my.wav";


### PR DESCRIPTION
Thanks for making such a wonder tool.  This is my first official pull request, here goes.

According to the documentation Titanium.Filesystem.getFile "takes a variable number of arguments, where each argument is treated as a path component." ([source](http://docs.appcelerator.com/titanium/latest/#!/api/Titanium.Filesystem-method-getFile)).

The argsToPath method in uglify was concatenating arguments together but was not separating them with path separators when more than two arguments were used in Titanium.Filesystem.getFile.

For example if the original source looked like:
Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "a_folder", "a_file");

The argsToPath method would generate:
Ti.Filesystem.getFile(__p.file(Ti.Filesystem.applicationDataDirectory + require("/api/TiShadow").currentApp + "/" + ("a_folder" + "a_file")))

The file would not be found because there was no path separator between the folder and the file.

I added two test cases in the filesystem.js expected/fixtures files to demonstrate the behavior (you can see this if you don't apply the change to uglify).
