### PR TITLE
Added flag to 'spec' to only clear spec files

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Here are a full list of options:
     -t, --type <type>      testing library
     -j, --jshint           analyse code with JSHint
     -x, --junit-xml        output report as JUnit XML
+    -C, --clear-spec-files clears only the spec files from the cache
 ```
 
 **NEW**: You can now select the testing library to use `jasmine`, `mocha-should` or `mocha-chai`. 

--- a/app/Resources/api/PlatformRequire.js
+++ b/app/Resources/api/PlatformRequire.js
@@ -128,6 +128,25 @@ exports.clearCache = function (list) {
 };
 
 /*
+ * clear require and global cache using a regular expression. any file
+ * that matches will be removed.
+ */
+exports.clearCacheWithRegEx = function (regex) {
+  for (var key in cache) {
+    if (cache.hasOwnProperty(key) && key.match(regex)) {
+      log.debug('Clearing: ' + key + ' from the require cache');
+      delete cache[key];
+    }
+  }
+  for (var a in global_context) {
+    if (global_context.hasOwnProperty(a) && !_.contains(global_keys, a) && a.match(regex)) {
+      log.debug('Clearing: ' + a + ' from global context');
+      delete global_context[a];
+    }
+  }
+};
+
+/*
  * new repl
  */
 exports.eval = function(message) {

--- a/app/Resources/api/Spec.js
+++ b/app/Resources/api/Spec.js
@@ -21,10 +21,15 @@ function loadSpecs(name, base, filter) {
   });
 }
 
-exports.run = function (name, junitxml, type) {
+exports.run = function (name, junitxml, type, clearSpecFiles) {
   var jasmine;
   //For a new environment reset
-  p.clearCache();
+  if (clearSpecFiles) {
+    p.clearCacheWithRegEx(/_spec\.js/);
+  }
+  else {
+    p.clearCache();
+  }
   type = type || "jasmine";
   if (type === "jasmine") {
     jasmine = require('/lib/jasmine').jasmine;

--- a/app/Resources/api/TiShadow.js
+++ b/app/Resources/api/TiShadow.js
@@ -232,7 +232,7 @@ function loadRemoteZip(name, url, data, version_property) {
       // Launch
       if (data && data.spec && data.spec.run) {
         exports.currentApp = path_name;
-        require("/api/Spec").run(path_name, data.spec.junitxml, data.spec.type);
+        require("/api/Spec").run(path_name, data.spec.junitxml, data.spec.type, data.spec.clearSpecFiles);
       } else if (data && data.patch && data.patch.run) {
         require('/api/PlatformRequire').clearCache(data.patch.files);
       } else  {

--- a/cli/support/api.js
+++ b/cli/support/api.js
@@ -74,7 +74,7 @@ exports.newBundle = function(file_list) {
   fn("bundle", {
     bundle:config.bundle_file,
     deployOnly: config.isDeploy || undefined,
-    spec: {run: config.isSpec, junitxml: config.isJUnit, type: config.specType},
+    spec: {run: config.isSpec, junitxml: config.isJUnit, type: config.specType, clearSpecFiles: config.clearSpecFiles},
     locale: config.locale,
     platform: config.platform,
     patch : {run: config.isPatch, files: file_list}

--- a/cli/support/config.js
+++ b/cli/support/config.js
@@ -112,6 +112,7 @@ config.init = function(env) {
   config.isDeploy   = env._name === "deploy";
   config.isTailing  = env.tailLogs || config.isSpec;
   config.isJUnit    = env.junitXml;
+  config.clearSpecFiles = env.clearSpecFiles;
   config.isREPL     = env._name === "repl";
   config.isPipe     = env.pipe;
   config.isBundle   = env._name === "bundle";

--- a/cli/tishadow
+++ b/cli/tishadow
@@ -91,6 +91,7 @@ program.command('spec')
   .option('-P, --platform <platform>', 'target platform')
   .option('-s, --skip-alloy-compile', 'skip automatic alloy compilation')
   .option('-D, --include-dot-files', 'includes dot files in the bundle (defaults to false)')
+  .option('-C, --clear-spec-files', 'clears only the spec files from the cache')
   .action(compiler);
 
 program.command('close')


### PR DESCRIPTION
We started using TiShadow for test automation in our applications.  We wanted a mechanism to rerun specs on a running appified application but not clear the entire require and global caches each time.  So a new flag was added to 'tishadow spec' to only clear spec files from the caches.  If the flag is not specified then 'tishadow spec' behaves as it currently does and clears the entire cache.

I went ahead and updated the README.md file to reflect the new flag, not sure if you wanted this so I can happily remove it if necessary.
