### PR TITLE
Removing ms from description of watch-delay

### DIFF
--- a/cli/tishadow
+++ b/cli/tishadow
@@ -156,8 +156,8 @@ program.command('config')
   .option('-p, --port <port>', 'set default server port')
   .option('-r, --room <room>', 'set default server room')
   .option('-t, --type <type>', 'default testing library')
-  .option('-w, --watch-delay <millis>',    'time to wait before responding to for changes (default: 0ms)')
-  .option('-i, --watch-interval <millis>', 'time to wait between checking files for changes (default: 100ms)')
+  .option('-w, --watch-delay <millis>',    'time to wait before responding to for changes (default: 0)')
+  .option('-i, --watch-interval <millis>', 'time to wait between checking files for changes (default: 100)')
   .action(config.write);
 
 program.command('app')


### PR DESCRIPTION
Confusing since the value needs to be a number, no `ms`.
