### PR TITLE
Prevents double --project-dir

### DIFF
--- a/plugin/yy.tishadow/1.0/hooks/shadow.js
+++ b/plugin/yy.tishadow/1.0/hooks/shadow.js
@@ -37,8 +37,15 @@ function preCompileHook(isExpress) {
 
     // pass through arguments
     var args = build.cli.argv.$_
-               .filter(function(el) { return el !== "--shadow" && el !== "--tishadow" && el !== "--appify"})
-               .concat(["--project-dir", new_project_dir]);
+               .filter(function(el) { return el !== "--shadow" && el !== "--tishadow" && el !== "--appify"});
+               
+    if ((index = args.indexOf('-p')) >= 0) {
+      args[index + 1] = new_project_dir;
+    } else if (index === args.indexOf('--project-dir') >= 0) {
+      args[index + 1] = new_project_dir;
+    } else {
+      args.concat(["--project-dir", new_project_dir]);
+    }
 
     if (build.certDeveloperName) {
       args.push("--developer-name");


### PR DESCRIPTION
If the build args already had a project-dir (e.g. when used in combination with titanium-grunt) they will be joined to an array causing an exception in the CLI. I'll report this on JIRA but this fixes it as well.
