### PR TITLE
copy directory under module/commonjs  and .bundle files when appify

### DIFF
--- a/cli/support/appify.js
+++ b/cli/support/appify.js
@@ -122,7 +122,7 @@ exports.build = function(env) {
       ['iphone','android','blackberry','mobileweb','tizen','commonjs'].forEach(function(platform) {
         if(fs.existsSync(path.join(config.resources_path,platform))) {
           wrench.copyDirSyncRecursive(path.join(config.resources_path,platform),path.join(dest_resources,platform),{
-            filter: new RegExp("(\.png|images|res-.*|fonts|\.otf|\.ttf)$","i"),
+            filter: new RegExp("(\.png|images|res-.*|fonts|\.otf|\.ttf|\.bundle)$","i"),
             whitelist: true
           });
         }


### PR DESCRIPTION
- commonjs module is missing.
- .bundle files has to be copied in specific case. (eg. [Google map module for ios](http://gitt.io/component/com.mekansal.gmapios))
