### PR TITLE
Add support for --host

### DIFF
--- a/plugin/yy.tishadow/1.0/hooks/shadow.js
+++ b/plugin/yy.tishadow/1.0/hooks/shadow.js
@@ -50,7 +50,7 @@ function preCompileHook(isExpress) {
       args.splice(index, 2);
     }
                
-    if ((index = args.indexOf('--project-dir')) >= 0) {
+    if ((index = args.indexOf('--project-dir')) >= 0 || (index = args.indexOf('-d')) >= 0) {
       args[index + 1] = new_project_dir;
     } else {
       args.push("--project-dir", new_project_dir);


### PR DESCRIPTION
- Fixes missing `var index;`.
- Removes search for `-d` which is never there since TiCLI translates this to `--project-dir`.
- Adds support for `--host` or `-o` to select the host for express.

The last one I need to select `localhost` for testing offline scenarios in sim/emulator.

@dbankier tested both the addition and the change, apart and in combination.
@yomybaby please test again ;)
