### PR TITLE
Fixes requires to Module's JavaScript Entry File (the.module.id.js)

### DIFF
--- a/cli/support/compiler.js
+++ b/cli/support/compiler.js
@@ -197,11 +197,23 @@ function beginCompile(callback) {
   	fs.mkdirs(assets_list.dirs, config.module_path);
     // add files for processing 
     process_tasks = process_tasks.concat(assets_list.files.map(function(file) {
-      return _.bind(prepare, null, path.join(config.assets_path,file), path.join(config.tishadow_src, config.module_name, file));
+      var fileName = file.slice(0,file.lastIndexOf('.'));
+      if(fileName == config.module_name){
+      	return _.bind(prepare, null, path.join(config.assets_path,file), path.join(config.tishadow_src, file));
+      } else {
+      	return _.bind(prepare, null, path.join(config.assets_path,file), path.join(config.tishadow_src, config.module_name, file));
+      }
     }));
     console.log(process_tasks);
     // modify for bundling
-    assets_list.files = assets_list.files.map(function(file) { return config.module_name + "/" + file;});
+    assets_list.files = assets_list.files.map(function(file) {
+      var filePath = config.module_name + "/" + file;
+      var fileName = file.slice(0,file.lastIndexOf('.'));
+      if(fileName == config.module_name){
+      	filePath = file;
+      }
+      return filePath;
+    });
   }
   
   async.series([


### PR DESCRIPTION
Before, the module's JS entry file was zipped inside the folder named with the module id, so requires to the module's public api in the form:

```
require('the.module.id') 
```

were not working due the file was located on:

```
the.module.id/the.module.id.js
```

With this change requires to the module's JS entry file are working, without rewriting any code. Also requires to any other file inside the module still work.
