### PR TITLE
Uglify Ti.Filesystem.getFile to maintain Titanium getFile API compatibility 

### DIFF
--- a/app/Resources/api/PlatformRequire.js
+++ b/app/Resources/api/PlatformRequire.js
@@ -111,6 +111,24 @@ exports.file = function(extension) {
 };
 
 /*
+ * Asset Redirection - ByPass for file method. 
+ * Parses the whole list of argument and merges them using a safe structure
+ */
+exports.getFile = function() {
+  var extension = '';
+  for(var i=0; i<arguments.length; i++){
+  	var argument = arguments[i];
+  	//Only adds a slash when left arguments don't have it
+  	if(extension.charAt(extension.length-1) != '/' && argument.charAt(0) != '/' && i != 0){
+	  extension += '/' + argument;
+  	} else {
+  	  extension += argument;
+  	}
+  }
+  return exports.file(extension);
+};
+
+/*
  * clear require and global cache
  */
 // if a list of files is provided it will selectively clear the cache

--- a/cli/support/uglify.js
+++ b/cli/support/uglify.js
@@ -105,7 +105,7 @@ var convert = new UglifyJS.TreeTransformer(null, function(node){
       }
       if (node.expression.end.value === "getFile" &&
           node.expression.expression.property === "Filesystem") {
-				node.args = [functionCall("__p.file", [argsToPath(node.args)])];
+				node.args = [functionCall("__p.getFile", node.args)];
 				return node;
       }
 

--- a/test/expected/filesystem.js
+++ b/test/expected/filesystem.js
@@ -1,11 +1,21 @@
-Ti.Filesystem.getFile(__p.file(Ti.Filesystem.applicationDataDirectory + require("/api/TiShadow").currentApp + "/" + "sounds/my.wav"));
+Ti.Filesystem.getFile(__p.getFile(Ti.Filesystem.applicationDataDirectory + require("/api/TiShadow").currentApp + "/" + "sounds/my.wav"));
 
-Ti.Filesystem.getFile(__p.file(Ti.Filesystem.applicationDataDirectory + require("/api/TiShadow").currentApp + "/" + "sounds/my.wav"));
+Ti.Filesystem.getFile(__p.getFile(Ti.Filesystem.applicationDataDirectory + require("/api/TiShadow").currentApp + "/", "sounds/my.wav"));
 
-Ti.Filesystem.getFile(__p.file(Ti.Filesystem.applicationDataDirectory + require("/api/TiShadow").currentApp + "/" + ("sounds" + "/") + "my.wav"));
+Ti.Filesystem.getFile(__p.getFile(Ti.Filesystem.applicationDataDirectory + require("/api/TiShadow").currentApp + "/", "sounds", "my.wav"));
 
-Ti.Filesystem.getFile(__p.file(Ti.Filesystem.applicationDataDirectory + require("/api/TiShadow").currentApp + "/" + ("sounds" + "/") + ("music" + "/") + "my.wav"));
+Ti.Filesystem.getFile(__p.getFile(Ti.Filesystem.applicationDataDirectory + require("/api/TiShadow").currentApp + "/", "sounds", "music", "my.wav"));
 
 Ti.Filesystem.getApplicationDataDirectory() + require("/api/TiShadow").currentApp + "/";
 
 Ti.Filesystem.applicationDataDirectory + require("/api/TiShadow").currentApp + "/" + "sounds/my.wav";
+
+Ti.Filesystem.getFile(__p.getFile("/appdata-private://testApp/", "/testDir/"));
+
+Ti.Filesystem.getFile(__p.getFile("appdata-private://testApp/", "/testDir/"));
+
+Ti.Filesystem.getFile(__p.getFile("appdata-private://testApp", "/testDir/"));
+
+Ti.Filesystem.getFile(__p.getFile("appdata-private://testApp", "testDir/"));
+
+Ti.Filesystem.getFile(__p.getFile("appdata-private://testApp", "testDir"));

--- a/test/fixtures/filesystem.js
+++ b/test/fixtures/filesystem.js
@@ -9,3 +9,9 @@ Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "sounds", "my.wav");
 Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "sounds", "music", "my.wav");
 Ti.Filesystem.getResourcesDirectory();
 Ti.Filesystem.resourcesDirectory + "sounds/my.wav";
+
+Ti.Filesystem.getFile("/appdata-private://testApp/","/testDir/");
+Ti.Filesystem.getFile("appdata-private://testApp/","/testDir/");
+Ti.Filesystem.getFile("appdata-private://testApp","/testDir/");
+Ti.Filesystem.getFile("appdata-private://testApp","testDir/");
+Ti.Filesystem.getFile("appdata-private://testApp","testDir");


### PR DESCRIPTION
This change takes a more conservative approach to https://github.com/dbankier/TiShadow/pull/290,
It only changes Ti.Filesystem.getFile calls to use a new introduced method in PlatformRequire which adds "/" to path entries only if they are needed, and doesn't mask bugs that could be found if running directly without TiShadow.
Other usages of PlatformRequire.file are not changed in any way.
Test fixtures updated to reflect the change.
