### PR TITLE
Make tishadow watch files by extension.

### DIFF
--- a/cli/support/config.js
+++ b/cli/support/config.js
@@ -21,7 +21,7 @@ function getAppName(callback) {
   tiapp.find(process.cwd(),function(err,result) {
     if (err ) {
       if (!config.globalCmd) {
-      	
+
       	if (fs.existsSync(path.join(process.cwd(), 'timodule.xml')) && fs.existsSync(path.join(process.cwd(), 'manifest'))) {
 	      var data = fs.readFileSync(path.join(process.cwd(),'manifest'));
 	          base = process.cwd();
@@ -34,7 +34,7 @@ function getAppName(callback) {
 	          	callback(timod);
 	          	return;
 	          }
-	      
+
 	    } else {
           logger.error("Script must be run within a Titanium project.");
 	    }
@@ -90,13 +90,13 @@ config.buildPaths = function(env, callback) {
     config.fs_map_path       = path.join(config.tishadow_build, 'fs_map.json');
 
     var app_name = config.app_name = result.name[0] || "bundle";
-    
+
     config.isModule = fs.existsSync(config.assets_path) && result.isModule;
     if (config.isModule) {
       config.module_name = app_name;
       config.module_path = path.join(config.tishadow_src, config.module_name);
     }
-    
+
     config.bundle_name       = config.bundle_name || app_name;
     config.bundle_file       = path.join(config.tishadow_dist, config.bundle_name + ".zip");
     config.jshint_path       = fs.existsSync(config.alloy_path) ? config.alloy_path : config.resources_path;
@@ -132,11 +132,13 @@ config.init = function(env) {
   config.specType     = env.type || config.type  || "jasmine";
   config.runCoverage  = env.coverage;
   config.instrumentedfiles = {}; //stored instrumented files
-  
+
   // commands that go through buildPath/init but done mandate a being in the project path
   config.globalCmd  = _.contains(['clear','close','screenshot','repl'], env._name);
   config.watchInterval = config.watchInterval || 100;
   config.watchDelay    = config.watchDelay || 0;
+  config.fileTypesToWatch = config.fileTypesToWatch || "**/*";
+
   if (['jasmine','mocha-chai','mocha-should','jasmine2'].indexOf(config.specType) === -1) {
     logger.error("Invalid test library, please choose from: jasmine, mocha-should or mocha-chai");
     process.exit(-1);

--- a/cli/tishadow
+++ b/cli/tishadow
@@ -13,7 +13,7 @@ var api            = require('./support/api'),
     program        = require('commander'),
     fs             = require('fs'),
     path           = require('path'),
-    spawn          = require('./support/spawn'), 
+    spawn          = require('./support/spawn'),
     updateNotifier = require('update-notifier'),
     gaze           = require('gaze');
 
@@ -141,7 +141,7 @@ program.command('screenshot')
   .option('-x, --scale <ratio>', 'ratio (as decimal) to scale screenshot')
   .option('-P, --platform <platform>', 'target platform')
   .action(api.screenshot);
-  
+
 program.command('log')
   .description('tail server logs'.grey)
   .option('-o, --host <host>', 'server host name / ip address')
@@ -169,7 +169,7 @@ program.command('app')
   .option('-d, --destination <path>', 'target path for generated project')
   .option('-u, --upgrade', 'upgrade an existing tishadow app')
   .action(function(env) {
-    if (env.upgrade) { 
+    if (env.upgrade) {
       require('./support/appify').copyCoreProject(env);
     } else {
       program.prompt("Enter app id [com.yydigital.tishadowapp]: ", function(appid) {
@@ -211,7 +211,7 @@ function execute() {
 if (config.isWatching) {
   config.buildPaths({},function() {
     var paths = [config.isAlloy ? "app" :"Resources", "i18n", "spec"].map(function(p) {
-      return path.join(p,"**/*");
+      return path.join(p, config.fileTypesToWatch);
     });
     var responder;
     gaze(paths, {cwd:config.base, interval: config.watchInterval}, function(err, watcher){
@@ -225,6 +225,6 @@ if (config.isWatching) {
     });
   });
   api.startRepl();
-} 
+}
 
 execute();


### PR DESCRIPTION
hi  dbankier,

  My team is using coffee-script, every time the coffee file changed, the tishadow will trigger a new compile. 
  It's impossible to add the 'compile coffeescript' process to the alloy.jmk's "pre:compile", because this will make the "Alloy compile" infinite. 

  So I added an option "fileTypesToWatch" to the tishadow configure, usage is quite simple:

```json
// edit ~/.tishadow.json
{
  "fileTypesToWatch": "**/*.{js, tss, xml}"
}
```

  This will make tishadow only watch "js/tss/xml" files' change, and will of course ignore the 'coffee files' change.  

thanks 
Siwei