### PR TITLE
mkdirp.sync can return null or string. 

### DIFF
--- a/cli/support/appify.js
+++ b/cli/support/appify.js
@@ -37,11 +37,10 @@ _.templateSettings = {
 
 exports.copyCoreProject = function(env) {
   var dest = env.destination || ".";
+  mkdirp.sync(dest);
   if (!fs.existsSync(dest) || !fs.lstatSync(dest).isDirectory()) {
-    if(mkdirp.sync(dest)){
-      logger.error("Could not create destination directory.");
-      return false;
-    }
+    logger.error("Could not create destination directory.");
+    return false;
   }
   if (dest === ".") {
     logger.error("You really don't want to write to the current directory.");


### PR DESCRIPTION
mkdirp.sync return null if already exsist or return the first directory that had to be created.

So it should be follow below order.

1. run `mkdir.sync`
2. Check destination exist or not.
