### PR TITLE
add condition : program.arg exist #438

### DIFF
--- a/cli/tishadow
+++ b/cli/tishadow
@@ -207,7 +207,7 @@ program.command('express')
 
 function execute(filename) {
   var argv = process.argv.slice(0);
-  if(program.args[0]) {
+  if(program.args && program.args[0]) {
     program.args[0].alloyCompileFile =config.alloyCompileFile =  undefined;
   }
   if ((argv[2] === "run" || argv[2] === "spec") && filename && !filename.match(/app.tss$/)) {


### PR DESCRIPTION
#438 https://github.com/dbankier/TiShadow/commit/8fcf4efabfa448c33787281182b2fb38ca4c1504
When install, there is a error.

```
/Users/yomybaby/.nvm/versions/node/v0.12.7/lib/node_modules/tishadow/cli/tishadow:210
  if(program.args[0]) {
                 ^
TypeError: Cannot read property '0' of undefined
```

This PR is fix that. 