### PR TITLE
Bump tiapp to a version that doesn't use sys

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "pkginfo": "^0.2.3",
     "socket.io": "^0.9.17",
     "socket.io-client": "^0.9.17",
-    "tiapp": "0.0.2",
+    "tiapp": "^0.0.3",
     "uglify-js": "^2.4.24",
     "underscore": "^1.4.4",
     "update-notifier": "^0.1.10",


### PR DESCRIPTION
Hi @dbankier!

Following up on https://jira.appcelerator.org/browse/CLI-907 I saw that while https://github.com/dbankier/TiShadow/commit/33f680f9005abd277fa7e9249bcd8e815dd855d2 took care of the use of sys in TiShadow itself, it is still depending on a version of tiapp that does use sys. So this bumps it to 0.0.3 to deal with that.

Thx!
Fokke