### PR TITLE
Update tiapp dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tishadow",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "dependencies": {
     "archiver": "^0.4.8",
     "async": "^0.2.10",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "pkginfo": "^0.2.3",
     "socket.io": "^0.9.17",
     "socket.io-client": "^0.9.17",
-    "tiapp": "0.0.2",
+    "tiapp": "0.0.3",
     "uglify-js": "^2.4.24",
     "underscore": "^1.4.4",
     "update-notifier": "^0.1.10",


### PR DESCRIPTION
Fixes the following error:

```
(node) sys is deprecated. Use util instead.
```

Bumped version for your convenience. :)