### PR TITLE
Host of avd

### DIFF
--- a/app/Resources/appify.js
+++ b/app/Resources/appify.js
@@ -34,7 +34,9 @@ var host;
 if(Ti.Platform.model === "Simulator") {
   host = "127.0.0.1";
 }else if(Ti.Platform.manufacturer === "unknown") {
-  host = "10.0.0.2";
+  host = "10.0.2.2";
+}else if(Ti.Platform.manufacturer === "Genymotion") {
+  host = "10.0.3.2";
 }else {
   host = "{{host}}";
 }

--- a/app/Resources/appify.js
+++ b/app/Resources/appify.js
@@ -30,10 +30,19 @@ if (!target.exists()) {
   Compression.unzip(Ti.Filesystem.applicationDataDirectory + "/" + path_name, Ti.Filesystem.resourcesDirectory + "/" + path_name + '.zip',true);
 }
 
+var host;
+if(Ti.Platform.model === "Simulator") {
+  host = "127.0.0.1";
+}else if(Ti.Platform.manufacturer === "unknown") {
+  host = "10.0.0.2";
+}else {
+  host = "{{host}}";
+}
+
 //Call Home
 TiShadow.connect({
   proto: "{{proto}}",
-  host : Ti.Platform.model === "Simulator" ? "127.0.0.1" : "{{host}}",
+  host : host,
   port : "{{port}}",
   room : "{{room}}",
   name : Ti.Platform.osname + ", " + Ti.Platform.version + ", " + Ti.Platform.address


### PR DESCRIPTION
Android Emulator can access localhost via "10.0.x.2".

- Android Virtual Device of Google (Ti.Platform.manufacturer is "undefined"):  10.0.2.2 
- Genymotion : 10.0.3.2 