### PR TITLE
Fix a crash on iOS

### DIFF
--- a/app/Resources/api/Includes.js
+++ b/app/Resources/api/Includes.js
@@ -300,6 +300,7 @@ if (Ti.Platform.osname !== "android"){
     Titanium.UI.iOS.NavigationWindow.showNavBar,
     Titanium.UI.iOS.PreviewAction,
     Titanium.UI.iOS.PreviewActionGroup,
+    Titanium.UI.iOS.PreviewContext,
     Titanium.UI.iOS.PushBehavior,
     Titanium.UI.iOS.SnapBehavior,
     Titanium.UI.iOS.TabbedBar,

--- a/app/Resources/api/TiShadow.js
+++ b/app/Resources/api/TiShadow.js
@@ -292,15 +292,17 @@ function loadRemoteBundle(url) {
 }
 
 function parseArguments() {
-  cmd = Ti.App.getArguments();
-  if ( (typeof cmd == 'object') && cmd.hasOwnProperty('url') ) {
-    if ( cmd.url !== url ) {
-      url = cmd.url;
-      if (url.substring(0, 8) === 'tishadow') {
-        loadRemoteBundle(url.replace("tishadow", "http"));
+  setTimeout(function() {
+    cmd = Ti.App.getArguments();
+    if ( (typeof cmd == 'object') && cmd.hasOwnProperty('url') ) {
+      if ( cmd.url !== url ) {
+        url = cmd.url;
+        if (url.substring(0, 8) === 'tishadow') {
+          loadRemoteBundle(url.replace("tishadow", "http"));
+        }
       }
     }
-  }
+  }, 0);
 }
 
 var url = '';


### PR DESCRIPTION
With the new SearchableIndex API, the `Ti.App.getArguments()` called on immediate startup, cause an irrecoverable error and a crash.

With a `setTimeout` the JS queue is executed after the Titanium thread, and there's no error.

But I don't know if the `setTimeout` breaks somethings in TiShadow and in the remote bundle load, I've never used it.