### PR TITLE
Fix alloy compile error with -l option

### DIFF
--- a/cli/support/compiler.js
+++ b/cli/support/compiler.js
@@ -104,7 +104,7 @@ module.exports = function(env, callback) {
       }
       async.detectSeries(config.platform, function(platform, callback) {
         logger.info("Compiling Alloy for " + platform);
-        var args = ['compile', '-b','-l', '2', '--platform', platform, '--config', 'sourcemap=false'];
+        var args = ['compile', '-b','-l', 'info', '--platform', platform, '--config', 'sourcemap=false'];
         if (config.alloyCompileFile) {
           args[7] = "sourcemap=false,file="+config.alloyCompileFile;
         }


### PR DESCRIPTION
It seems that the Appcelerator Cli doens't support passing number value in -l (--logLevel) and a recent update of [bunyan](https://github.com/trentm/node-bunyan) (version higher than 1.5.1), a dependency of  `appc-logger` will throw an error when compiling.

`$ appc alloy compile -l 2 --platform ios`


`An uncaught exception was thrown!
unknown level name: "2"
unknown level name: "2"
Error: unknown level name: "2"
    at Function.resolveLevel (/Users/hy/.appcelerator/install/5.2.0/package/node_modules/appc-logger/node_modules/bunyan/lib/bunyan.js:291:19)
    at Logger.logger.level (/Users/hy/.appcelerator/install/5.2.0/package/node_modules/appc-logger/lib/problem.js:85:25)
    at Object.<anonymous> (/Users/hy/.appcelerator/install/5.2.0/package/bin/appc:76:8)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3`

However, if we run alloy command without appc prefix, the number value seems work fine, for example:
`alloy compile -l 2 --platform ios`

 So I've done a workaround for this by passing string value to -l option instead of number.

`appc alloy compile -l info --platform ios`