### PR TITLE
fix #481 : support i18n with Alloy 1.8.x or later

### DIFF
--- a/cli/support/config.js
+++ b/cli/support/config.js
@@ -14,7 +14,8 @@ var path = require("path"),
     platforms = ['iphone','android','blackberry','mobileweb','tizen'],
     tiapp = require("tiapp"),
     glob = require("glob"),
-    config = {};
+    config = {},
+    spawnSync = require('child_process').spawnSync;
 
 //get app name
 function getAppName(callback) {
@@ -101,6 +102,7 @@ config.buildPaths = function(env, callback) {
     config.bundle_file       = path.join(config.tishadow_dist, config.bundle_name + ".zip");
     config.jshint_path       = fs.existsSync(config.alloy_path) ? config.alloy_path : config.resources_path;
     config.isAlloy = fs.existsSync(config.alloy_path);
+    config.isAlloy1_8_later = config.isAlloy && spawnSync("alloy",["-v"]).stdout >= "1.8.0";
     if (!config.platform && config.isAlloy) {
       var deploymentTargets = [];
       result['deployment-targets'][0].target.forEach(function(t) {

--- a/cli/tishadow
+++ b/cli/tishadow
@@ -223,9 +223,14 @@ function execute(filename) {
 
 if (config.isWatching) {
   config.buildPaths({},function() {
-    var paths = [config.isAlloy ? "app" :"Resources", "i18n", "spec"].map(function(p) {
+    var paths = [config.isAlloy ? "app" :"Resources", "spec"];
+    if(!config.isAlloy1_8_later){
+      paths.push('i18n');
+    }
+    paths = paths.map(function(p) {
       return path.join(p,"**/*");
     });
+    
     if (config.watchExclude) {
       config.watchExclude.split(",").forEach(function(g) {
         paths.push("!" + g.trim());


### PR DESCRIPTION
if Alloy version is 1.8.x or later, `i18n` path should be removed from watching path list. 
:smile: 
fix #481 