### PR TITLE
fix error missing alloy log when config.useAppcCLI is false

### DIFF
--- a/cli/support/compiler.js
+++ b/cli/support/compiler.js
@@ -104,7 +104,12 @@ module.exports = function(env, callback) {
       }
       async.detectSeries(config.platform, function(platform, callback) {
         logger.info("Compiling Alloy for " + platform);
-        var args = ['compile', '-b','-l', 'info', '--platform', platform, '--config', 'sourcemap=false'];
+        var args;
+        if (config.useAppcCLI) {
+          args = ['compile', '-b','-l', 'info', '--platform', platform, '--config', 'sourcemap=false'];
+        } else {
+          args = ['compile', '-b','-l', '2', '--platform', platform, '--config', 'sourcemap=false'];
+        }
         if (config.alloyCompileFile) {
           args[7] = "sourcemap=false,file="+config.alloyCompileFile;
         }


### PR DESCRIPTION
As @yomybaby suggested, #480 fix should only be applied when config.useAppcCLI is true.