### PR TITLE
error log notification to OS notification center

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "mkdirp": "^0.3.5",
     "mocha": "^1.12.1",
     "multiparty": "^4.1.2",
+    "node-notifier": "^4.6.0",
     "pkginfo": "^0.2.3",
     "socket.io": "^0.9.17",
     "socket.io-client": "^0.9.17",

--- a/server/logger.js
+++ b/server/logger.js
@@ -4,6 +4,7 @@
  */
 
 var config = require("../cli/support/config");
+var path = require('path');
 require('colors');
 
 color = {
@@ -18,6 +19,17 @@ color = {
 };
 
 exports.log = function(level, name, msg) {
+  
+  if(level === 'ERROR' || level ==='FAIL'){
+    var notifier = require('node-notifier');
+    notifier.notify({
+      title: level,
+      message: msg,
+      icon: path.join(__dirname, '..','app','Resources','iphone','appicon@2x.png'), 
+      sound: true
+    });
+  }
+  
   var msg =  "[" + level + "] "  
   + (name ? "[" + name + "] ": "")
   + msg;


### PR DESCRIPTION
This is a new feature.
When `ts run` command got an error, system notification will appear (will disappear few sec later)

<img width="407" alt="_2016__8__11__ _10_43" src="https://cloud.githubusercontent.com/assets/621215/17576699/7143602a-5fb0-11e6-8905-9b5ed5c9ef34.png">

This is so useful with `ts @ run` command. :)