### PR TITLE
When appify, copy platform/ios directory

### DIFF
--- a/cli/support/appify.js
+++ b/cli/support/appify.js
@@ -121,7 +121,7 @@ exports.build = function(env) {
       }
       mkdirp.sync(dest_platform);
       //copy splash screen and icons
-      ['iphone','android','blackberry','mobileweb','tizen','commonjs'].forEach(function(platform) {
+      ['iphone','ios','android','blackberry','mobileweb','tizen','commonjs'].forEach(function(platform) {
         if(fs.existsSync(path.join(config.resources_path,platform))) {
           wrench.copyDirSyncRecursive(path.join(config.resources_path,platform),path.join(dest_resources,platform),{
             filter: new RegExp("(\.png|images|res-.*|fonts|\.otf|\.ttf|\.bundle)$","i"),


### PR DESCRIPTION
On iOS10 and Xcode 8, *.entitlements files under platform/ios directory.
It should be copied when appify.

- case 1 : push notification ( https://jira.appcelerator.org/browse/TIMOB-23908 )
- case 2 : Facebook module on simulator ( https://jira.appcelerator.org/browse/TIMOB-23890 )