### PR TITLE
fix #504

### DIFF
--- a/cli/tishadow
+++ b/cli/tishadow
@@ -249,7 +249,7 @@ if (config.isWatching) {
       if (!ready) {return};
       logger.debug(event + ": " + filepath);
       if (!responder) responder = setTimeout(function() {
-        execute(config.boost ? filepath.replace(config.base,"").substring(1) : undefined);
+        execute(config.boost ? filepath : undefined);
         responder = undefined;
       }, config.watchDelay);
     })


### PR DESCRIPTION
#504 
When `all` event of `chokidar`, file path parameter is a relative path. So you don't have to `replace` and `substring`. It breaks boost mode.

If you print a log of ` filepath.replace(config.base,"").substring(1)`, it start `pp/controllers...` instead of `app/controllers...`

I'm not sure file path is a relative path also on Windows system. I use OS X. :)