### PR TITLE
Make boost feature to compile all changed files at once

### DIFF
--- a/cli/support/compiler.js
+++ b/cli/support/compiler.js
@@ -111,7 +111,7 @@ module.exports = function(env, callback) {
           args = ['compile', '-b','-l', '2', '--platform', platform, '--config', 'sourcemap=false'];
         }
         if (config.alloyCompileFile) {
-          args[7] = "sourcemap=false,file="+config.alloyCompileFile;
+          args[7] = "file="+config.alloyCompileFile.split(',').join(',file=');
         }
         var alloy_command;
         if (config.useAppcCLI) {

--- a/cli/tishadow
+++ b/cli/tishadow
@@ -15,7 +15,8 @@ var api            = require('./support/api'),
     path           = require('path'),
     spawn          = require('./support/spawn'),
     updateNotifier = require('update-notifier'),
-    chokidar       = require('chokidar');
+    chokidar       = require('chokidar'),
+    _ = require("underscore");
 
 // check if watch enabled
 var at_index = process.argv.indexOf("@");
@@ -205,14 +206,14 @@ program.command('express')
     });
   });
 
-function execute(filename) {
+function execute(filenames) {
   var argv = process.argv.slice(0);
   if(program.args && program.args[0]) {
     program.args[0].alloyCompileFile =config.alloyCompileFile =  undefined;
   }
-  if ((argv[2] === "run" || argv[2] === "spec") && filename && !filename.match(/app.tss$/)) {
+  if ((argv[2] === "run" || argv[2] === "spec") && filenames && !_.find(filenames, function(f){ return f.match(/app.tss$/)}) ) {
     argv.push("-f");
-    argv.push(filename);
+    argv.push(filenames.join(','));
   }
   program.parse(argv);
   // Display help on an invalid command
@@ -238,9 +239,14 @@ if (config.isWatching) {
         paths.push("!" + g.trim());
       });
     }
-    var responder;
     var ready = false;
-
+    
+    var changedFiles = [];
+    var debouncedExcute = _.debounce(function () {
+      execute(changedFiles);
+      changedFiles = [];
+    },config.watchDelay);
+    
     var watcher = chokidar.watch(paths, {
       interval: config.watchInterval,
       cwd: config.base
@@ -248,10 +254,8 @@ if (config.isWatching) {
     .on('all', function watcher(event, filepath) {
       if (!ready) {return};
       logger.debug(event + ": " + filepath);
-      if (!responder) responder = setTimeout(function() {
-        execute(config.boost ? filepath : undefined);
-        responder = undefined;
-      }, config.watchDelay);
+      changedFiles.push(filepath);
+      debouncedExcute();
     })
     .on('ready', ()=> {
       logger.debug("watcher ready")

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "socket.io-client": "^0.9.17",
     "tiapp": "0.0.3",
     "uglify-js": "^2.4.24",
-    "underscore": "^1.4.4",
+    "underscore": "^1.8.3",
     "update-notifier": "^0.1.10",
     "wrench": "~1.4.4"
   },


### PR DESCRIPTION
## Notice
This PR is dpends on https://github.com/appcelerator/alloy/pull/803.
Before https://github.com/appcelerator/alloy/pull/803 is merged, never allow this PR. :) I'll keep my eyes on Alloy PR and let you know.

## Background and Description
Tishadow boost is so fast. But there is a bad case.
When modify several files and save all at once, `ts @ run -u` build only one controller. So to apply all changes, you should run `ts run` addtionally.
I just want make to compile all changed files at once without addtional excute `run` command.
