### PR TITLE
i18n L() methond does not working at Ti SDK 6.0.0+

### DIFF
--- a/app/Resources/api/Localisation.js
+++ b/app/Resources/api/Localisation.js
@@ -23,7 +23,7 @@ function loadFile() {
   var strings = doc.getElementsByTagName("string");
   for(var i = 0; i< strings.length; i++) {
     var node = strings.item(i);
-    var value = node.text;
+    var value = node.textContent;
     if(node.hasAttributes()) {
       for(var att_index = 0; att_index < node.attributes.length; att_index++) {
         var att = node.attributes.item(att_index);


### PR DESCRIPTION
'text' property is not exist in Titanium.XML.Node.
Need to change 'textContent'.
http://docs.appcelerator.com/platform/latest/#!/api/Titanium.XML.Node-property-textContent

This only occurs at Ti SDK 6.0.0+.
The Appcelerator manual does not write that 'text' was deprecated.
Maybe it's a documentation error.

(error)
<img width="663" alt="2016-12-02 2 41 57" src="https://cloud.githubusercontent.com/assets/7310854/20824259/8a6009ea-b89e-11e6-9a45-78f8b72b15c7.png">

(correct)
<img width="663" alt="2016-12-02 2 50 57" src="https://cloud.githubusercontent.com/assets/7310854/20824290/cc4d24be-b89e-11e6-9bad-b7bb0534db8c.png">
