### PR TITLE
A bug in websocket when using node 6.3+ https://github.com/websockets…

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "uglify-js": "^2.4.24",
     "underscore": "^1.4.4",
     "update-notifier": "^0.1.10",
-    "wrench": "~1.4.4"
+    "wrench": "~1.4.4",
+    "ws": "^1.1.1"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
A bug in websocket when using node 6.3+ https://github.com/websockets/ws/issues/778

/usr/local/lib/node_modules/tishadow/node_modules/ws/lib/Receiver.js:317
    default: srcBuffer.copy(dstBuffer, dstOffset, 0, length); break;
                       ^

RangeError: out of range index
    at RangeError (native)
    at fastCopy (/usr/local/lib/node_modules/tishadow/node_modules/ws/lib/Receiver.js:317:24)
    at Receiver.add (/usr/local/lib/node_modules/tishadow/node_modules/ws/lib/Receiver.js:78:3)
    at Socket.firstHandler (/usr/local/lib/node_modules/tishadow/node_modules/ws/lib/WebSocket.js:663:22)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:176:18)
    at Socket.Readable.push (_stream_readable.js:134:10)
    at TCP.onread (net.js:548:20)