### PR TITLE
Working i18n check instead of bad Alloy 1.8 check

### DIFF
--- a/cli/support/config.js
+++ b/cli/support/config.js
@@ -102,7 +102,6 @@ config.buildPaths = function(env, callback) {
     config.bundle_file       = path.join(config.tishadow_dist, config.bundle_name + ".zip");
     config.jshint_path       = fs.existsSync(config.alloy_path) ? config.alloy_path : config.resources_path;
     config.isAlloy = fs.existsSync(config.alloy_path);
-    config.isAlloy1_8_later = config.isAlloy && spawnSync("alloy",["-v"]).stdout >= "1.8.0";
     if (!config.platform && config.isAlloy) {
       var deploymentTargets = [];
       result['deployment-targets'][0].target.forEach(function(t) {

--- a/cli/tishadow
+++ b/cli/tishadow
@@ -226,7 +226,10 @@ function execute(filenames) {
 if (config.isWatching) {
   config.buildPaths({},function() {
     var paths = [config.isAlloy ? "app" :"Resources"];
-    if(!config.isAlloy1_8_later && fs.existsSync(path.join(config.base, 'i18n'))){
+    if (
+      fs.existsSync(path.join(config.base, 'i18n')) && 
+      !fs.existsSync(path.join(config.base, 'i18n', 'alloy_generated'))
+      ){
       paths.push('i18n');
     }
     if (config.isSpec) {


### PR DESCRIPTION
With newest Alloy 1.10, this commit:
https://github.com/yomybaby/TiShadow/commit/a316dc97f7ea0a9832c8d8b3c60554d76ad4bc0e#diff-256682f228d184536ba8bacc0666d086R105
breaks everything, because `1.10` < `1.8` (of course).

- - -
@yomybaby did you really compared versions using `>=` ??
....
Next time use a procedure like this: https://github.com/trimethyl/trimethyl/blob/master/cli.js#L87
- - - 

I fixed by, instead of checking Alloy version, if `i18n/alloy_generated` file exists.

