### PR TITLE
fix: handle script-phases and iOS app extensions

### DIFF
--- a/cli/support/appify.js
+++ b/cli/support/appify.js
@@ -219,6 +219,20 @@ exports.build = function(env) {
         );
       }
 
+      if (fs.existsSync(path.join(config.base, 'extensions'))) {
+        var extensionsPath = path.join(dest, 'extensions');
+
+        mkdirp.sync(extensionsPath);
+        wrench.copyDirSyncRecursive(path.join(config.base, 'extensions'), extensionsPath);
+      }
+
+      if (fs.existsSync(path.join(config.base, 'scripts'))) {
+        var scriptsPath = path.join(dest, 'scripts');
+
+        mkdirp.sync(scriptsPath);
+        wrench.copyDirSyncRecursive(path.join(config.base, 'scripts'), scriptsPath);
+      }
+
       // copy tiapp.xml and inject modules
       var source_tiapp = fs.readFileSync(
         path.join(config.base, 'tiapp.xml'),


### PR DESCRIPTION
This pull request adds two common directories that currently cause the build to fail:

- extensions/
  - Used to handle native iOS app extensions (like watchOS, home widgets, ..)
- scripts/
  - Used to inject iOS run-script phase scripts like the Firebase DSYM upload